### PR TITLE
Add a file to expose the markdown parser

### DIFF
--- a/markdown_subtemplate/parse.py
+++ b/markdown_subtemplate/parse.py
@@ -1,0 +1,1 @@
+from .infrastructure import markdown_transformer


### PR DESCRIPTION
I had noticed that this package could only process files so I decided to create a little alias over the inner `transform` function. All it does it import `markdown_transform` and create a reference to `transform` as `parse`.